### PR TITLE
Install Android command-line tools before manual build

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -14,6 +14,18 @@ jobs:
           distribution: temurin
           java-version: '8'
 
+      - name: Install Android command-line tools
+        run: |
+          set -e
+          mkdir -p "$ANDROID_HOME/cmdline-tools"
+          cd "$ANDROID_HOME/cmdline-tools"
+          curl -fo commandlinetools.zip https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip
+          rm -rf latest cmdline-tools
+          unzip -qo commandlinetools.zip
+          mv cmdline-tools latest
+          rm commandlinetools.zip
+          echo "$ANDROID_HOME/cmdline-tools/latest/bin" >> "$GITHUB_PATH"
+
       - name: Install Android SDK components
         run: |
           yes | sdkmanager --licenses


### PR DESCRIPTION
## Summary
- download and install the Android command-line tools during the manual build workflow
- add the command-line tools directory to the PATH so sdkmanager is available for later steps

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_b_68e1db6834a8832988285b0dd84836de