### PR TITLE
Update manual workflow Java configuration

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -9,10 +9,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4
+      - name: Set up Java 17 for Android SDK Manager
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '8'
+          java-version: '17'
 
       - name: Install Android command-line tools
         run: |
@@ -37,11 +38,18 @@ jobs:
           rm -rf ../appcompat_v7_4
           cp -R "$ANDROID_HOME/extras/android/support/v7/appcompat" ../appcompat_v7_4
 
+      - name: Set up Java 8 for Ant build
+        id: setup-java-8
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '8'
+
       - name: Generate Ant files and build
         env:
           ANDROID_HOME: ${{ env.ANDROID_HOME }}
         run: |
-          export JAVA_HOME=${{ steps.setup-java.outputs.java-home }}
+          export JAVA_HOME=${{ steps.setup-java-8.outputs.java-home }}
           android update project --path . --target android-19
           ant debug
 


### PR DESCRIPTION
## Summary
- add a Java 17 setup step before installing Android SDK tools so sdkmanager runs on a supported runtime
- run a separate Java 8 setup immediately before the Ant build to keep the legacy build compatible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e1dc53b590832987122e4090cc2aa1