### PR TITLE
Add legacy support extras to manual build workflow

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -31,7 +31,8 @@ jobs:
         run: |
           yes | sdkmanager --licenses
           sdkmanager "platform-tools" "build-tools;19.1.0" "platforms;android-19" \
-            "extras;android;m2repository" "extras;google;m2repository" "tools"
+            "extras;android;m2repository" "extras;google;m2repository" \
+            "extras;android;support" "tools"
 
       - name: Prepare appcompat support project
         run: |


### PR DESCRIPTION
## Summary
- include the legacy Android support extras in the manual build workflow to download the appcompat project

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e1dd4d47d48329bb04e2d34dadeb9a